### PR TITLE
Prevent the configuration file from being loaded twice

### DIFF
--- a/src/rc-config-loader.js
+++ b/src/rc-config-loader.js
@@ -80,7 +80,7 @@ function findConfig({ parts, loaderByExt, configFileName, packageJSON, packageJS
                 continue;
             }
             return {
-                config: loader(configLocation),
+                config: result,
                 filePath: configLocation
             };
         }


### PR DESCRIPTION
From what I understood, the `findConfig` method is currently running the configuration loader twice, if a single loader is used per extension. This can be a problem when the loaded config file has side-effects that shouldn't run more than once.