### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ console.log(rcfile("bar", {
     defaultExtension: [".json", ".yml", ".js"]
 }));
 
-// try to load as .yml, but it is not json
+// try to load as .json, but it is not json
 // throw Error
 try {
     rcfile("unknown", {

--- a/example.js
+++ b/example.js
@@ -51,7 +51,7 @@ console.log(
     })
 );
 
-// try to load as .yml, but it is not json
+// try to load as .json, but it is not json
 // throw Error
 try {
     rcfile("unknown", {


### PR DESCRIPTION
* `try to load as . yml, but it is not json` => `try to load as .json, but it is not json`