### PR TITLE
Add support for .cjs file extension

### DIFF
--- a/src/rc-config-loader.ts
+++ b/src/rc-config-loader.ts
@@ -8,6 +8,7 @@ import JSON5 from "json5";
 
 const debug = require("debug")("rc-config-loader");
 const defaultLoaderByExt = {
+    ".cjs": loadJSConfigFile,
     ".js": loadJSConfigFile,
     ".json": loadJSONConfigFile,
     ".yaml": loadYAMLConfigFile,
@@ -18,7 +19,7 @@ const defaultOptions = {
     // does look for `package.json`
     packageJSON: false,
     // treat default(no ext file) as some extension
-    defaultExtension: [".json", ".yaml", ".yml", ".js"],
+    defaultExtension: [".json", ".yaml", ".yml", ".js", ".cjs"],
     cwd: process.cwd(),
 };
 
@@ -40,7 +41,7 @@ export interface rcConfigLoaderOption {
 type Loader = <R extends object>(fileName: string, suppress: boolean) => R;
 
 const selectLoader = (defaultLoaderByExt: { [index: string]: Loader }, extension: string) => {
-    if (![".json", ".yaml", ".yml", ".js"].includes(extension)) {
+    if (!defaultOptions.defaultExtension.includes(extension)) {
         throw new Error(`${extension} is not supported.`);
     }
     return defaultLoaderByExt[extension];

--- a/test/fixtures/.bazrc.cjs
+++ b/test/fixtures/.bazrc.cjs
@@ -1,0 +1,4 @@
+"use strict";
+module.exports = {
+    baz: "baz"
+};

--- a/test/rc-config-loader-test.ts
+++ b/test/rc-config-loader-test.ts
@@ -43,6 +43,15 @@ describe("rc-config-loader", () => {
         assert.deepStrictEqual(config, { bar: "bar" });
     });
 
+    it("should read cjs config in current directory", () => {
+        const results = rcFile("baz", { cwd: path.join(__dirname, "fixtures") });
+        if (!results) {
+            throw new Error("not found");
+        }
+        const { config } = results;
+        assert.deepStrictEqual(config, { baz: "baz" });
+    });
+
     it("should read js config by { configFileName }", () => {
         const results = rcFile("textlint", { configFileName: path.join(__dirname, "fixtures", ".textlintrc") });
         if (!results) {


### PR DESCRIPTION
This PR adds default support for the .cjs file extension.

> A `.cjs` file is a CommonJS JavaScript file: [nodejs.org/api/packages.html#:~:text=Files%20ending%20with%20.cjs](https://nodejs.org/api/packages.html#:~:text=Files%20ending%20with%20.cjs), [babeljs.io/docs/en/config-files#:~:text=babel.config.cjs%20and%20.babelrc.cjs](https://babeljs.io/docs/en/config-files#:~:text=babel.config.cjs%20and%20.babelrc.cjs).
> 
> It’s common for CommonJS CLI tools to accept `.cjs` files as config files, so that projects with `"type": "module"` in their `package.json` have a way to specify the configuration for the CommonJS tool.

https://github.com/raineorshine/npm-check-updates/issues/1051