### PR TITLE
fix(deps): update json5@2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",
-    "json5": "^2.2.1",
+    "json5": "^2.2.2",
     "require-from-string": "^2.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,10 +602,10 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
-json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+json5@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.2.tgz#64471c5bdcc564c18f7c1d4df2e2297f2457c5ab"
+  integrity sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==
 
 lilconfig@2.0.4:
   version "2.0.4"


### PR DESCRIPTION
JSON5@2.2.2 fix Prototype Pollution.

- [Prototype Pollution in JSON5 via Parse Method · CVE-2022-46175 · GitHub Advisory Database](https://github.com/advisories/GHSA-9c47-m6qq-7p4h)
- [Release v2.2.2 · json5/json5](https://github.com/json5/json5/releases/tag/v2.2.2)
